### PR TITLE
Setup RSpec, Travis CI, Rubocop, small refactorings, drop support for Rails < 4 and Ruby < 2.4.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+.byebug_history
 active_record_query_trace-*.gem
+coverage/
 Gemfile.lock

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,26 @@
+require: rubocop-rspec
+
+AllCops:
+  DisplayStyleGuide: true
+  TargetRubyVersion: 2.3
+
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
+
+Metrics/BlockLength:
+  Enabled: false
+
+Metrics/LineLength:
+  Max: 120
+
+MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
+MultilineOperationIndentation:
+  EnforcedStyle: indented
+
+Style/Documentation:
+  Enabled: false
+
+RSpec/NestedGroups:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,53 @@
+language: ruby
+# Ruby versions to run tests on.
+# We will not test on Ruby versions thar are no longer supported (EOL).
+# List of Ruby releases: https://www.ruby-lang.org/en/downloads/releases/
+# Maintenance status of each Ruby series https://www.ruby-lang.org/en/downloads/branches/
+rvm:
+  - 2.4.4
+  - 2.5.3
+  - 2.6.1
+  - ruby-head
+# Rails versions to run tests on.
+# We will not test on Rails versions thar are no longer supported (EOL).
+# List of Rails releases: https://rubygems.org/gems/rails/versions
+# Maintenance status of each Rails series: https://guides.rubyonrails.org/maintenance_policy.html
+env:
+  - RAILS_VERSION=4.2.11
+  - RAILS_VERSION=5.2.2
+  - RAILS_VERSION=6.0.0.beta2
+  - RAILS_VERSION=master
+matrix:
+  # When testing against the head or master (unreleased versions) of Ruby or
+  # Rails, failures may occur because the branch is unstable and not due to our
+  # project. For these cases, we'll allow failures until official versions are
+  # released.
+  allow_failures:
+    - env: RAILS_VERSION=master
+    - rvm: ruby-head
+  # Some Rails versions do not work with older Ruby versions.
+  exclude:
+    # Rails >= 6 requires Ruby version >= 2.5.0
+    - rvm: 2.4.4
+      env: RAILS_VERSION=6.0.0.beta2
+    - rvm: 2.4.4
+      env: RAILS_VERSION=master
+    # I was unable to get Ruby head to work with Bundler < 2, which is required by Rails 4.2.
+    - rvm: ruby-head
+      env: RAILS_VERSION=4.2.11
+# See https://docs.travis-ci.com/user/caching/#bundler
+cache: bundler
+sudo: false
+before_install:
+  # Rails ~> 4.2.x does not work with Bundle 2.0. The gem uninstall command
+  # removes any Bundler 2.x installed in RVM’s “global” gemset during the Ruby run
+  # time installation, which would be selected as the default bundle command. We
+  # ignore the failure from that command, because the failure most likely means
+  # that there was no matching Bundler version to uninstall.
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2' --no-document
+script:
+  - bundle exec rubocop
+  - bundle exec rspec
+notifications:
+  email: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,18 @@
+# frozen_string_literal: true
+
 source 'http://rubygems.org'
 gemspec
+
+# Travis CI sets the RAILS_VERSION environment variable (see .travis.yml).
+rails_version =
+  case ENV['RAILS_VERSION']
+  when 'master'
+    { github: 'rails/rails' }
+  when nil
+    # Default version, required for running tests locally without setting ENV['RAILS_VERSION'].
+    '>= 5.2.2'
+  else
+    "~> #{ENV['RAILS_VERSION']}"
+  end
+
+gem 'rails', rails_version

--- a/README.md
+++ b/README.md
@@ -1,95 +1,117 @@
-Logs the source of execution of all queries to the Rails log. Helpful to track down where queries are being executed in your application, for performance optimizations most likely.
+Displays a backtrace for each query in Rails' development console and log. 
+Allows you to track down where and when queries are executed in your application.
+Useful for performance optimizations and for finding where to start when making
+changes to a big application.
 
-## Install
+When enabled every query will be logged like:
 
-Install the latest stable release:
-
-`gem install active_record_query_trace`
-
-In Rails, add it to your Gemfile, then restart the server:
-
-```ruby
-gem 'active_record_query_trace'
 ```
+D, [2019-03-03T19:50:41.061115 #25560] DEBUG -- : User Load (0.1ms)  SELECT "users".* FROM "users"
+D, [2019-03-03T19:50:41.062492 #25560] DEBUG -- : Query Trace:
+      /media/ArquivosBruno/git_repositories/active-record-query-trace/lib/active_record_query_trace.rb:75:in `sql'
+      /home/bruno/.rvm/gems/ruby-2.5.3/gems/activesupport-5.2.2/lib/active_support/subscriber.rb:101:in `finish'
+      /home/bruno/.rvm/gems/ruby-2.5.3/gems/activesupport-5.2.2/lib/active_support/log_subscriber.rb:84:in `finish'
+      /home/bruno/.rvm/gems/ruby-2.5.3/gems/activesupport-5.2.2/lib/active_support/notifications/fanout.rb:104:in `finish'
+      /home/bruno/.rvm/gems/ruby-2.5.3/gems/activesupport-5.2.2/lib/active_support/notifications/fanout.rb:48:in `block in finish'
+```
+
+## Requirements
+- Ruby 2.4, 2.5 or 2.6;
+- Rails/ActiveRecord 4.2, 5.2, or 6 (can be used with or without Rails).
 
 ## Usage
 
-Enable it in an initializer:
+1. Install the latest stable release:
+   
+   A. *When using Rails:* add the following to your Gemfile, then restart the server:                      
+   ```ruby
+   gem 'active_record_query_trace'
+   ``` 
+ 
+   B. *When using ActiveRecord without Rails:* install manually:
+   ```ruby
+   gem install active_record_query_trace
+   ``` 
 
-```ruby
-ActiveRecordQueryTrace.enabled = true
-```
+2. Create an initializer within `config/initializers/` to enable the gem.
+If you want to customize how the gem behaves, you can add any combination of the
+following [options](#options) to the initializer as well.
+ 
+    ```ruby
+    ActiveRecordQueryTrace.enabled = true
+    ```
 
 ## Options
 
+#### Backtrace level
 There are three levels of debug.
 
 1. app - includes only files in your app/, lib/, and engines/ directories.
 2. rails - includes files in your app as well as rails.
-3. full - alternate output of full backtrace, useful for debugging gems.
+3. full - full backtrace, useful for debugging gems.
 
 ```ruby
 ActiveRecordQueryTrace.level = :app # default
 ```
 
-By default, a backtrace will be logged for every query, even cached queries that do not actually hit the database. You might find it useful not to print the backtrace for cached queries:
+#### Ignore cached queries
+By default, a backtrace will be logged for every query, even cached queries that 
+do not actually hit the database. You might find it useful not to print the backtrace
+for cached queries:
 
 ```ruby
 ActiveRecordQueryTrace.ignore_cached_queries = true # Default is false.
 ```
 
-Additionally, if you are working with a large app, you may wish to limit the number of lines displayed for each query.
+#### Limit the number of lines in the backtrace
+Additionally, if you are working with a large app, you may wish to limit the number 
+of lines displayed for each query.
 
 ```ruby
 ActiveRecordQueryTrace.lines = 10 # Default is 5. Setting to 0 includes entire trace.
 ```
 
-If you want the output can be colorized with a string of the color or a code. Valid colors are:
-'black', 'red', 'green', 'brown', 'blue', 'purple', 'cyan',
-'gray', 'dark gray', 'light red', 'light green', 'yellow', 'light blue',
-'light purple', 'light cyan', 'white'
+#### Colorize the backtrace
+If you want the output can be colorized with a string of the color or a code. 
+Valid colors are: `:black`, `:red`, `:green`, `:brown`, `:blue`, `:purple`, `:cyan`, 
+`:gray`, `:dark_gray`, `:light_red`, `:light_green`, `:yellow`, `:light_blue`, 
+`:light_purple`, `:light_cyan`, `:white`.
 
 ```ruby
-ActiveRecordQueryTrace.colorize = false # No colorization(default)
-ActiveRecordQueryTrace.colorize = 'light purple'
-ActiveRecordQueryTrace.colorize = true # Colorize in default color
-ActiveRecordQueryTrace.colorize = 35 # Magenta
+ActiveRecordQueryTrace.colorize = false           # No colorization (default)
+ActiveRecordQueryTrace.colorize = :light_purple   # Colorize in specific color
+ActiveRecordQueryTrace.colorize = true            # Colorize in default color
 ```
 
+## Authors
 
+- **Cody Caughlan** - Original author.
+- **Bruno Facca** - Current maintainer. [LinkedIn](https://www.linkedin.com/in/brunofacca/)
 
-## Output
+## Contributing
 
-When enabled every query source will be logged like:
+#### Bug reports
 
-```
-  IntuitAccount Load (1.2ms)  SELECT "intuit_accounts".* FROM "intuit_accounts" WHERE "intuit_accounts"."user_id" = 20 LIMIT 1
-Called from:
-  app/views/users/edit.html.haml:78:in `block in _app_views_users_edit_html_haml___1953197429694975654_70177901460360'
-  app/views/users/edit.html.haml:16:in `_app_views_users_edit_html_haml___1953197429694975654_70177901460360'
-```
+Please use the issue tracker to report any bugs.
 
-Requirements
-------------
-Rails 3+
+#### Test environment
 
-Copyright (c) 2011 Cody Caughlan
+This gem uses RSpec for testing. You can run the test suite by executing the
+`rspec` command. It has decent test coverage and the test suite taks less than
+a second to run due to using an in-memory SQLite DB.
 
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
+#### Developing
 
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
+1. Create an issue and describe your idea
+2. Fork it
+3. Create your feature branch (`git checkout -b my-new-feature`)
+4. Implement your changes;
+5. Run the test suite (`rspec`)
+6. Commit your changes (`git commit -m 'Add some feature'`)
+7. Publish the branch (`git push origin my-new-feature`)
+8. Create a Pull Request
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+## License
+
+Released under the [MIT License](https://opensource.org/licenses/MIT).
+

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,12 @@
-require "rubygems"
-require "bundler"
-require "bundler/gem_tasks"
+# frozen_string_literal: true
+
+require 'rubygems'
+require 'bundler'
+require 'bundler/gem_tasks'
 
 Bundler.setup
 
-desc "Default task"
+desc 'Default task'
 task :default do
-  puts "Hello"
+  puts 'Hello'
 end

--- a/active_record_query_trace.gemspec
+++ b/active_record_query_trace.gemspec
@@ -1,14 +1,25 @@
-$LOAD_PATH.unshift File.expand_path("../lib", __FILE__)
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'active_record_query_trace/version'
 
-Gem::Specification.new do |gem|
-  gem.name          = 'active_record_query_trace'
-  gem.version       = ActiveRecordQueryTrace::VERSION
-  gem.summary       = 'Print stack trace of all queries to the Rails log. Helpful to find where queries are being executed in your application.'
-  gem.description   = gem.summary
-  gem.authors       = ['Cody Caughlan', 'Bruno Facca']
-  gem.email         = 'bruno@facca.info'
-  gem.homepage      = 'https://github.com/brunofacca/active-record-query-trace'
-  gem.files         = Dir['lib/**/*']
-  gem.license       = 'MIT'
+Gem::Specification.new do |s|
+  s.name          = 'active_record_query_trace'
+  s.version       = ActiveRecordQueryTrace::VERSION
+  s.summary       = 'Print stack trace of all DB queries to the Rails log. ' \
+    'Helpful to find where queries are being executed in your application.'
+  s.description   = s.summary
+  s.authors       = ['Cody Caughlan', 'Bruno Facca']
+  s.email         = 'bruno@facca.info'
+  s.homepage      = 'https://github.com/brunofacca/active-record-query-trace'
+  s.files         = Dir['lib/**/*']
+  s.license       = 'MIT'
+  s.add_development_dependency 'activerecord'
+  s.add_development_dependency 'pry'
+  s.add_development_dependency 'pry-byebug'
+  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'rubocop-rspec'
+  s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'sqlite3', '~> 1.3.6'
 end

--- a/lib/active_record_query_trace.rb
+++ b/lib/active_record_query_trace.rb
@@ -1,8 +1,30 @@
-# encoding: UTF-8
-require 'active_support/log_subscriber'
-require 'active_record_query_trace/version'
+# frozen_string_literal: true
+
+require 'active_record/log_subscriber'
+require 'active_support/core_ext/hash/indifferent_access'
 
 module ActiveRecordQueryTrace
+  INDENTATION = ' ' * 6
+  BACKTRACE_PREFIX = "Query Trace:\n#{INDENTATION}"
+  COLORS = {
+    true => '38',
+    blue: '34',
+    light_red: '1;31',
+    black: '30',
+    purple: '35',
+    light_green: '1;32',
+    red: '31',
+    cyan: '36',
+    yellow: '1;33',
+    green: '32',
+    gray: '37',
+    light_blue: '1;34',
+    brown: '33',
+    dark_gray: '1;30',
+    light_purple: '1;35',
+    white: '1;37',
+    light_cyan: '1;36'
+  }.with_indifferent_access.freeze
 
   class << self
     attr_accessor :enabled
@@ -12,95 +34,109 @@ module ActiveRecordQueryTrace
     attr_accessor :colorize
 
     def logger
-      ActiveRecordQueryTrace::ActiveRecord::LogSubscriber.logger
+      ::ActiveRecord::LogSubscriber.logger
     end
 
     def logger=(new_logger)
-      ActiveRecordQueryTrace::ActiveRecord::LogSubscriber.logger = new_logger
+      ::ActiveRecord::LogSubscriber.logger = new_logger
     end
   end
 
-  module ActiveRecord
-    class LogSubscriber < ActiveSupport::LogSubscriber
+  class CustomLogSubscriber < ActiveRecord::LogSubscriber
+    def initialize
+      super
+      ActiveRecordQueryTrace.enabled = false
+      ActiveRecordQueryTrace.level = :app
+      ActiveRecordQueryTrace.lines = 5
+      ActiveRecordQueryTrace.ignore_cached_queries = false
+      ActiveRecordQueryTrace.colorize = false
+    end
 
-      def initialize
-        super
-        ActiveRecordQueryTrace.enabled = false
-        ActiveRecordQueryTrace.level = :app
-        ActiveRecordQueryTrace.lines = 5
-        ActiveRecordQueryTrace.ignore_cached_queries = false
-        ActiveRecordQueryTrace.colorize = false
+    # TODO: refactor this method and re-enable the following cops.
+    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/PerceivedComplexity
+    def sql(event)
+      return unless ActiveRecordQueryTrace.enabled
 
-        if ActiveRecordQueryTrace.level != :app
-          # Rails by default silences all backtraces that match Rails::BacktraceCleaner::APP_DIRS_PATTERN
-          Rails.backtrace_cleaner.remove_silencers!
-        end
-      end
-
-      def sql(event)
-        if ActiveRecordQueryTrace.enabled
-          index = begin
-            if ActiveRecordQueryTrace.lines == 0
-              0..-1
-            else
-              0..(ActiveRecordQueryTrace.lines - 1)
-            end
-          end
-
-          payload = event.payload
-          return if payload[:name] == 'SCHEMA'
-          return if ActiveRecordQueryTrace.ignore_cached_queries && payload[:cached]
-
-          cleaned_trace = clean_trace(caller)[index].join("\n     ")
-          debug("  Query Trace > " + colorize_text(cleaned_trace)) unless cleaned_trace.blank?
-        end
-      end
-
-      # Allow query to be colorized in the terminal
-      def colorize_text(text)
-        return text unless ActiveRecordQueryTrace.colorize
-        # Try to convert the choosen color from string to integer or try
-        # to use the colorize as the color code
-        colors = {
-          true => "38",       "blue" => "34",        "light red" => "1;31",
-          "black" => "30",    "purple" => "35",      "light green" => "1;32",
-          "red" => "31",      "cyan" => "36",        "yellow" => "1;33",
-          "green" => "32",    "gray" => "37",        "light blue" => "1;34",
-          "brown" => "33",    "dark gray" => "1;30", "light purple" => "1;35",
-          "white" => "1;37",  "light cyan" => "1;36"
-        }
-        color_code = colors[ActiveRecordQueryTrace.colorize] ||
-          ActiveRecordQueryTrace.colorize.to_s
-        unless /\d+(;\d+){0,1}/.match(color_code)
-          raise "Invalid color. Use one of #{ colors.keys } or a valid color code"
-        end
-        "\e[#{ color_code }m#{ text }\e[0m"
-      end
-
-      def clean_trace(trace)
-        # Rails relies on backtrace cleaner to set the application root directory filter
-        # the problem is that the backtrace cleaner is initialized before the application
-        # this ensures that the value of `root` used by the filter is set to the application root
-        if Rails.backtrace_cleaner.instance_variable_get(:@root) == '/'
-          Rails.backtrace_cleaner.instance_variable_set :@root, Rails.root.to_s
-        end
-
-        case ActiveRecordQueryTrace.level
-        when :full
-          trace
-        when :rails
-          Rails.respond_to?(:backtrace_cleaner) ? Rails.backtrace_cleaner.clean(trace) : trace
-        when :app
-          Rails.backtrace_cleaner.remove_silencers!
-          Rails.backtrace_cleaner.add_silencer { |line| not line =~ /^(app|lib|engines)\// }
-          Rails.backtrace_cleaner.clean(trace)
+      index = begin
+        if ActiveRecordQueryTrace.lines.zero?
+          0..-1
         else
-          raise "Invalid ActiveRecordQueryTrace.level value '#{ActiveRecordQueryTrace.level}' - should be :full, :rails, or :app"
+          0..(ActiveRecordQueryTrace.lines - 1)
         end
       end
 
-      attach_to :active_record
+      payload = event.payload
+      return if payload[:name] == 'SCHEMA' \
+        || payload[:sql] == 'begin transaction' \
+        || payload[:sql] == 'commit transaction'
+      return if ActiveRecordQueryTrace.ignore_cached_queries && payload[:cached]
 
+      cleaned_trace = clean_trace(original_trace)[index].join("\n" + INDENTATION)
+      debug(colorize_text(BACKTRACE_PREFIX + cleaned_trace)) unless cleaned_trace.blank?
+    end
+
+    def clean_trace(trace)
+      # Rails relies on backtrace cleaner to set the application root directory
+      # filter the problem is that the backtrace cleaner is initialized before
+      # the application this ensures that the value of `root` used by the filter
+      # is set to the application root
+      if Rails.backtrace_cleaner.instance_variable_get(:@root) == '/'
+        Rails.backtrace_cleaner.instance_variable_set :@root, Rails.root.to_s
+      end
+
+      case ActiveRecordQueryTrace.level
+      when :full
+        trace
+      when :rails
+        # Rails by default silences all backtraces that *do not* match
+        # Rails::BacktraceCleaner::APP_DIRS_PATTERN. In other words, the default
+        # silencer filters out all framework backtrace frames, leaving only the
+        # application frames.
+        Rails.backtrace_cleaner.remove_silencers!
+        Rails.backtrace_cleaner.add_silencer { |line| line =~ %r{^(app|lib|engines)/} }
+        Rails.backtrace_cleaner.clean(trace)
+      when :app
+        Rails.respond_to?(:backtrace_cleaner) ? Rails.backtrace_cleaner.clean(trace) : trace
+      else
+        raise "Invalid ActiveRecordQueryTrace.level value '#{ActiveRecordQueryTrace.level}' " \
+              '- should be :full, :rails, or :app'
+      end
+    end
+    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/CyclomaticComplexity
+    # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/PerceivedComplexity
+
+    # Allow query to be colorized in the terminal
+    def colorize_text(text)
+      return text unless ActiveRecordQueryTrace.colorize
+      "\e[#{color_code}m#{text}\e[0m"
+    end
+
+    attach_to :active_record
+
+    private
+
+    # Wrapper used for testing purposes.
+    def original_trace
+      caller
+    end
+
+    def color_code
+      color_code = COLORS[ActiveRecordQueryTrace.colorize]
+
+      error_msg = 'ActiveRecordQueryTrace.colorize was set to an invalid ' \
+           "color. Use one of #{COLORS.keys} or a valid color code."
+
+      raise error_msg unless valid_color_code?(color_code)
+      color_code
+    end
+
+    def valid_color_code?(color_code)
+      /\A\d+(;\d+)?\Z/.match?(color_code)
     end
   end
 end

--- a/lib/active_record_query_trace/version.rb
+++ b/lib/active_record_query_trace/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActiveRecordQueryTrace
   VERSION = '1.5.4'
 end

--- a/spec/active_record_query_trace_spec.rb
+++ b/spec/active_record_query_trace_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ActiveRecordQueryTrace do
+  it 'has a version number' do
+    expect(ActiveRecordQueryTrace::VERSION).not_to be nil
+  end
+end

--- a/spec/db/migrate/01_create_users.rb
+++ b/spec/db/migrate/01_create_users.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+SUPERCLASS =
+  if ActiveRecord.version < Gem::Version.new('5.0')
+    ActiveRecord::Migration
+  else
+    version = "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"
+    ActiveRecord::Migration[version]
+  end
+
+class CreateUsers < SUPERCLASS
+  def change
+    create_table :users do |t|
+      t.timestamps null: false
+    end
+  end
+end

--- a/spec/db/setup.rb
+++ b/spec/db/setup.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+MIGRATIONS_PATH = File.expand_path('migrate', __dir__)
+
+# Set up a database that resides in RAM
+ActiveRecord::Base.establish_connection(
+  adapter: 'sqlite3',
+  database: ':memory:'
+)
+
+# Dummy model
+class User < ActiveRecord::Base
+end
+
+ActiveRecord::Migration.verbose = false
+
+if defined?(ActiveRecord::MigrationContext)
+  ActiveRecord::MigrationContext.new(MIGRATIONS_PATH).up
+else
+  ActiveRecord::Migrator.migrate(MIGRATIONS_PATH, nil)
+end

--- a/spec/lib/active_record_query_trace_spec.rb
+++ b/spec/lib/active_record_query_trace_spec.rb
@@ -1,0 +1,231 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ActiveRecordQueryTrace do
+  let(:logger_io) { StringIO.new }
+  let(:logger) { Logger.new(logger_io) }
+  let(:log) { logger_io.string }
+  let(:log_subscriber) do
+    ActiveRecord::LogSubscriber.log_subscribers
+      .find { |ls| ls.class == ActiveRecordQueryTrace::CustomLogSubscriber }
+  end
+
+  before do
+    # If level is set to :app, the backtrace will be empty as there is no Rails
+    # application running in the gem test environment.
+    described_class.level = :full
+    described_class.enabled = true
+    ActiveRecord::Base.logger = logger
+  end
+
+  # Clean log after each example
+  after { logger_io.truncate(0) }
+
+  describe 'configuration options' do
+    describe '.enabled' do
+      it 'is disabled by default' do
+        # The first before block of this spec sets `enabled` to `true`. Here we
+        # call initialize to reset to the default value.
+        described_class::CustomLogSubscriber.new
+        expect(described_class.enabled).to eq(false)
+      end
+
+      context 'when enabled' do
+        before { described_class.enabled = true }
+
+        # TODO: improve this. Currently, it will pass if the prefix is there but the backtrace is not.
+        it 'adds backtrace to the log' do
+          User.create!
+          expect(log).to match(described_class::BACKTRACE_PREFIX)
+        end
+      end
+
+      context 'when disabled' do
+        before { described_class.enabled = false }
+
+        it 'does not add backtrace to the log' do
+          User.create!
+          expect(log).not_to match(described_class::BACKTRACE_PREFIX)
+        end
+      end
+    end
+
+    describe '.level' do
+      let(:app_frames) do
+        [
+          "/projects/my_rails_project/app/controllers/users_controller.rb:10:in `index'",
+          "/projects/my_rails_project/lib/foo.rb:10:in `bar'"
+        ]
+      end
+      let(:rails_frames) do
+        [
+          "/home/username/.rvm/gems/ruby-2.5.3/gems/actionpack-5.2.1.1/lib/action_controller/metal/foo.rb:6:in `bar'",
+          "/home/username/.rvm/gems/ruby-2.5.3/gems/activesupport-5.2.2/lib/active_support/subscriber.rb:101:in `foo'",
+          "/home/username/.rvm/gems/ruby-2.5.3/gems/puma-3.12.0/lib/puma/server.rb:332:in `block in run'"
+        ]
+      end
+
+      before do
+        # Reset to the default filters and silencers set by Rails' backtrace cleaner.
+        Rails.instance_variable_set(:@backtrace_cleaner, Rails::BacktraceCleaner.new)
+        # The first before block of this spec sets level to :full. Here we call
+        # initialize to reset to the default level.l
+        described_class::CustomLogSubscriber.new
+        described_class.enabled = true
+        allow(log_subscriber).to receive(:original_trace).and_return(app_frames + rails_frames)
+      end
+
+      it 'is set to :app by default' do
+        expect(described_class.level).to eq(:app)
+      end
+
+      context 'when set to :full' do
+        before do
+          described_class.level = :full
+          User.create!
+        end
+
+        it 'displays all backtrace frames' do
+          expect(log).to match(
+            /
+              .*#{Regexp.escape(described_class::BACKTRACE_PREFIX)}
+              #{Regexp.escape((app_frames + rails_frames).join("\n" + described_class::INDENTATION))}
+            /x
+          )
+        end
+      end
+
+      context 'when set to :rails' do
+        before do
+          described_class.level = :rails
+          User.create!
+        end
+
+        it 'only displays framework backtrace frames' do
+          expect(log).to match(
+            /
+              .*
+              #{Regexp.escape(described_class::BACKTRACE_PREFIX)}
+              #{Regexp.escape(rails_frames.join("\n" + described_class::INDENTATION))}
+            /x
+          )
+        end
+      end
+
+      context 'when set to :app' do
+        before do
+          described_class.level = :app
+          User.create!
+        end
+
+        # The default settings of Rails' backtrace cleaner replaces full paths
+        # in the backtrace with relative paths.
+        let(:app_frames_with_relative_path) { app_frames.map { |f| f.gsub("#{Rails.root}/", '') } }
+
+        it 'only displays application backtrace frames' do
+          expect(log).to match(
+            /
+              .*
+              #{Regexp.escape(described_class::BACKTRACE_PREFIX)}
+              #{Regexp.escape(app_frames_with_relative_path.join("\n" + described_class::INDENTATION))}
+            /x
+          )
+        end
+      end
+    end
+
+    describe '.lines' do
+      let(:frame) { "/projects/my_rails_project/app/controllers/users_controller.rb:10:in `index'" }
+      let(:bakctrace) { Array.new(30, frame) }
+
+      before do
+        described_class.enabled = true
+        allow(log_subscriber).to receive(:original_trace).and_return(bakctrace)
+      end
+
+      it 'is set to 5 by default' do
+        # Call initialize to reset to the default value.
+        described_class::CustomLogSubscriber.new
+        expect(described_class.lines).to eq(5)
+      end
+
+      [1, 5, 10, 20, 30].each do |lines|
+        context "when set to #{lines}" do
+          before do
+            described_class.lines = lines
+            User.create!
+          end
+
+          it "displays the last #{lines} #{'line'.pluralize(lines)} of the backlog" do
+            expect(log.scan(frame).size).to eq(lines)
+          end
+        end
+      end
+    end
+
+    describe '.ignore_cached_queries' do
+      before { described_class.enabled = true }
+
+      it 'is disabled by default' do
+        # Call initialize to reset to the default value.
+        described_class::CustomLogSubscriber.new
+        expect(described_class.ignore_cached_queries).to eq(false)
+      end
+
+      context 'when set to true' do
+        before do
+          described_class.ignore_cached_queries = true
+          # The second call to User.all.load will hit the cache
+          ActiveRecord::Base.cache { 2.times { User.all.load } }
+        end
+
+        it 'does not display the backtrace for cached queries' do
+          expect(log).not_to match(/CACHE User Load.*#{described_class::BACKTRACE_PREFIX}/m)
+        end
+      end
+
+      context 'when set to false' do
+        before do
+          described_class.ignore_cached_queries = false
+          # The second call to User.all.load will hit the cache
+          ActiveRecord::Base.cache { 2.times { User.all.load } }
+        end
+
+        it 'displays the backtrace for cached queries' do
+          expect(log).to match(/CACHE.*#{described_class::BACKTRACE_PREFIX}/m)
+        end
+      end
+    end
+
+    describe '.colorize' do
+      it 'is disabled by default' do
+        # Call initialize to reset to the default value.
+        described_class::CustomLogSubscriber.new
+        expect(described_class.colorize).to eq(false)
+      end
+
+      described_class::COLORS.except(true).each do |color_name, color_code|
+        context "When ActiveRecordQueryTrace.colorize is set to #{color_name.to_s.humanize.downcase}" do
+          let(:regexp) do
+            /
+              \e\[#{color_code}m                                    # Start colorizing with the selected color
+              #{Regexp.escape(described_class::BACKTRACE_PREFIX)}   # The backtrace prefix (e.g., Query Trace:)
+              .*                                                    # The actual backtrace
+              \e\[0m                                                # Reset to the default color
+            /xm
+          end
+
+          before do
+            described_class.colorize = color_name
+            User.create!
+          end
+
+          it 'displays the backtrace with the selected color then resets to the default color' do
+            expect(log).to match(regexp)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'simplecov'
+SimpleCov.start
+
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+
+require 'active_record'
+require 'active_record_query_trace'
+require 'db/setup'
+require 'pry'
+require 'pry-byebug'
+
+RSpec.configure do |config|
+  config.formatter = :documentation
+end
+
+module Rails
+  module_function
+
+  # Fake Rails root path for specs (since we don't have an actual Rails app in this gem's test environment)
+  def root
+    '/projects/my_rails_project'
+  end
+
+  def backtrace_cleaner
+    @backtrace_cleaner ||= begin
+      # Relies on Active Support, so we have to lazy load to postpone definition until Active Support has been loaded
+      require 'rails/backtrace_cleaner'
+      Rails::BacktraceCleaner.new
+    end
+  end
+end


### PR DESCRIPTION
- Setup RSpec and SQLite 3 with in-memory DB for testing;
- Setup Rubocop, fix all offenses except the ones about method length and complexity, which require further refactoring;
- Setup Travis CI to test the project with multiple Ruby and Rails versions;
- Small refactorings in the module/class nesting and others to make the code easier to test;
- Drop support for Rails < 4 and Ruby < 2.4;
- Update readme.