### PR TITLE
Improve backtrace cleaner silencers for :app level

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,11 @@
+## 1.6.2 (2019-03-12)
+
+* Improve backtrace cleaner silencers for `:app` level. When .level is set to
+`:app`, only display files within `Rails.root`. When set to `:rails`, only
+display files outside of `Rails.root`;
+
+* Add mininum Ruby version to gemspec.
+
 ## 1.6.1 (2019-03-10)
 
 * Minor fixes and improvements such as adding Rails 4.0.0 to the CI and adding

--- a/active_record_query_trace.gemspec
+++ b/active_record_query_trace.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.homepage      = 'https://github.com/brunofacca/active-record-query-trace'
   s.files         = Dir['lib/**/*']
   s.license       = 'MIT'
+  s.required_ruby_version = '~> 2.3'
   s.add_development_dependency 'activerecord', '>= 4.0.0'
   s.add_development_dependency 'pry', '>= 0.12.2'
   s.add_development_dependency 'pry-byebug', '>= 3.7.0'

--- a/lib/active_record_query_trace/version.rb
+++ b/lib/active_record_query_trace/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveRecordQueryTrace
-  VERSION = '1.6.1'
+  VERSION = '1.6.2'
 end


### PR DESCRIPTION
- When .level is set to :app, only display files within Rails.root
- When set to :rails, only display files outside of Rails.root
- Add mininum Ruby version to gemspec