### PR TITLE
Limit read queries to SELECT statements

### DIFF
--- a/lib/active_record_query_trace.rb
+++ b/lib/active_record_query_trace.rb
@@ -88,7 +88,7 @@ module ActiveRecordQueryTrace
     end
 
     def db_read_query?(payload)
-      !payload[:sql].match(/(INSERT|UPDATE|DELETE)/)
+      !payload[:sql] =~ /\ASELECT\s/i
     end
 
     def fully_formatted_trace


### PR DESCRIPTION
Other statements like SET are possible, and these should be considered writes.

This includes a regexp optimization:

- Anchor the pattern to the start of string
- Avoid instantiating match data