### PR TITLE
Fix the `colorize = true` setting

### DIFF
--- a/lib/active_record_query_trace.rb
+++ b/lib/active_record_query_trace.rb
@@ -178,7 +178,7 @@ module ActiveRecordQueryTrace
       # Backward compatibility for string color names with space as word separator.
       @color_code =
         case ActiveRecordQueryTrace.colorize
-        when Symbol then COLORS[ActiveRecordQueryTrace.colorize]
+        when Symbol, true then COLORS[ActiveRecordQueryTrace.colorize]
         when String then COLORS[ActiveRecordQueryTrace.colorize.tr("\s", '_').to_sym]
         end
     end

--- a/spec/lib/active_record_query_trace_spec.rb
+++ b/spec/lib/active_record_query_trace_spec.rb
@@ -303,7 +303,7 @@ describe ActiveRecordQueryTrace do
         expect(described_class.colorize).to eq(false)
       end
 
-      described_class::COLORS.except(true).each do |color_name, color_code|
+      described_class::COLORS.each do |color_name, color_code|
         context "When ActiveRecordQueryTrace.colorize is set to #{color_name.to_s.humanize.downcase}" do
           let(:regexp) do
             /
@@ -325,14 +325,16 @@ describe ActiveRecordQueryTrace do
             end
           end
 
-          context 'with a string as the color name and space as word separator' do
-            before do
-              described_class.colorize = color_name.to_s.tr('_', "\s") # e.g., 'light purple'
-              User.create!
-            end
+          unless color_name == true
+            context 'with a string as the color name and space as word separator' do
+              before do
+                described_class.colorize = color_name.to_s.tr('_', "\s") # e.g., 'light purple'
+                User.create!
+              end
 
-            it 'displays the backtrace with the selected color then resets to the default color' do
-              expect(log).to match(regexp)
+              it 'displays the backtrace with the selected color then resets to the default color' do
+                expect(log).to match(regexp)
+              end
             end
           end
         end


### PR DESCRIPTION
The `ActiveRecordQueryTrace.colorize = true` is mentioned in the [README](https://github.com/brunofacca/active-record-query-trace#colorize-the-backtrace) and the default color is specified in the `COLORS` array, but the actual implementation and test were missing.
