### PR TITLE
Fix regression displaying cached queries in Rails 4.2.x

### DIFF
--- a/lib/active_record_query_trace.rb
+++ b/lib/active_record_query_trace.rb
@@ -62,12 +62,11 @@ module ActiveRecordQueryTrace
     private
 
     def cached_query?(payload)
-      return false unless ActiveRecordQueryTrace.ignore_cached_queries 
+      return false unless ActiveRecordQueryTrace.ignore_cached_queries
       payload[:cached] || payload[:name] == 'CACHE'
     end
 
     # rubocop:disable Metrics/CyclomaticComplexity
-    # rubocop:disable Metrics/PerceivedComplexity
     # TODO: refactor and remove rubocop:disable comments.
     def display_backtrace?(payload)
       ActiveRecordQueryTrace.enabled \
@@ -78,7 +77,6 @@ module ActiveRecordQueryTrace
         && display_backtrace_for_query_type?(payload)
     end
     # rubocop:enable Metrics/CyclomaticComplexity
-    # rubocop:enable Metrics/PerceivedComplexity
 
     def display_backtrace_for_query_type?(payload)
       case ActiveRecordQueryTrace.query_type

--- a/lib/active_record_query_trace.rb
+++ b/lib/active_record_query_trace.rb
@@ -61,6 +61,11 @@ module ActiveRecordQueryTrace
 
     private
 
+    def cached_query?(payload)
+      return false unless ActiveRecordQueryTrace.ignore_cached_queries 
+      payload[:cached] || payload[:name] == 'CACHE'
+    end
+
     # rubocop:disable Metrics/CyclomaticComplexity
     # rubocop:disable Metrics/PerceivedComplexity
     # TODO: refactor and remove rubocop:disable comments.
@@ -68,7 +73,7 @@ module ActiveRecordQueryTrace
       ActiveRecordQueryTrace.enabled \
         && !transaction_begin_or_commit_query?(payload) \
         && !schema_query?(payload) \
-        && !(ActiveRecordQueryTrace.ignore_cached_queries && (payload[:cached] || payload[:name] == 'CACHE')) \
+        && !cached_query?(payload) \
         && !(ActiveRecordQueryTrace.suppress_logging_of_db_reads && db_read_query?(payload)) \
         && display_backtrace_for_query_type?(payload)
     end

--- a/lib/active_record_query_trace.rb
+++ b/lib/active_record_query_trace.rb
@@ -68,7 +68,7 @@ module ActiveRecordQueryTrace
       ActiveRecordQueryTrace.enabled \
         && !transaction_begin_or_commit_query?(payload) \
         && !schema_query?(payload) \
-        && !(ActiveRecordQueryTrace.ignore_cached_queries && payload[:cached]) \
+        && !(ActiveRecordQueryTrace.ignore_cached_queries && (payload[:cached] || payload[:name] == 'CACHE')) \
         && !(ActiveRecordQueryTrace.suppress_logging_of_db_reads && db_read_query?(payload)) \
         && display_backtrace_for_query_type?(payload)
     end

--- a/spec/lib/active_record_query_trace_spec.rb
+++ b/spec/lib/active_record_query_trace_spec.rb
@@ -279,7 +279,7 @@ describe ActiveRecordQueryTrace do
         end
 
         it 'does not display the backtrace for cached queries' do
-          expect(log).not_to match(/CACHE User Load.*#{described_class::BACKTRACE_PREFIX}/m)
+          expect(log).not_to match(/CACHE.*#{described_class::BACKTRACE_PREFIX}/m)
         end
       end
 


### PR DESCRIPTION
Resolves an issue where ignore_cached_queries = true was ineffective in Rails 4.2.x due to a change in the pay the payload was structured in rails 5.x