### PR TITLE
Add ability to provide custom backtrace cleaner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ rails_version =
     { github: 'rails/rails' }
   when nil
     # Default version, required for running tests locally without setting ENV['RAILS_VERSION'].
-    '>= 5.2.2'
+    '~> 5.2'
   else
     ENV['RAILS_VERSION']
   end

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+## master
+
+* Add ability to provide custom backtrace cleaner.
+
 ## 1.6.2 (2019-03-12)
 
 * Improve backtrace cleaner silencers for `:app` level. When .level is set to

--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ There are three levels of debug.
 ActiveRecordQueryTrace.level = :app # default
 ```
 
+If you need more control you can provide a custom bactrace cleaner using the `:custom` level. For example:
+
+```ruby
+ActiveRecordQueryTrace.level = :custom
+require "rails/backtrace_cleaner"
+ActiveRecordQueryTrace.backtrace_cleaner = Rails::BacktraceCleaner.new.tap do |bc|
+  bc.remove_filters!
+  bc.remove_silencers!
+  bc.add_silencer { |line| line =~ /\b(active_record_query_trace|active_support|active_record|another_gem)\b/ }
+end
+```
+
 #### Display the trace only for read or write queries
 You can choose to display the backtrace only for DB reads, writes or both.
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ ActiveRecordQueryTrace.backtrace_cleaner = Rails::BacktraceCleaner.new.tap do |b
 end
 ```
 
+It's not necessary to create an instance of `Rails::BacktraceCleaner`, you can use any object responding to `#clean` or even
+a lambda/proc:
+
+```ruby
+ActiveRecordQueryTrace.backtrace_cleaner = ->(trace) {
+  trace.reject { |line| line =~ /\b(active_record_query_trace|active_support|active_record|another_gem)\b/ }
+}
+```
+
 #### Display the trace only for read or write queries
 You can choose to display the backtrace only for DB reads, writes or both.
 

--- a/spec/lib/active_record_query_trace_spec.rb
+++ b/spec/lib/active_record_query_trace_spec.rb
@@ -134,6 +134,27 @@ describe ActiveRecordQueryTrace do
           )
         end
       end
+
+      context 'when custom backtrace cleaner is set' do
+        before do
+          described_class.level = :custom
+          described_class.backtrace_cleaner = Rails::BacktraceCleaner.new.tap do |bc|
+            bc.add_silencer { |line| line =~ /gems|controllers/ }
+          end
+
+          User.create!
+        end
+
+        it 'only displays lines matching custom cleaner' do
+          expect(log).to match(
+            %r{
+              .*
+              #{Regexp.escape(described_class::BACKTRACE_PREFIX)}
+              .*lib/foo\.rb\:10:in
+            }x
+          )
+        end
+      end
     end
 
     describe '.query_type' do

--- a/spec/lib/active_record_query_trace_spec.rb
+++ b/spec/lib/active_record_query_trace_spec.rb
@@ -148,7 +148,26 @@ describe ActiveRecordQueryTrace do
         it 'only displays lines matching custom cleaner' do
           expect(log).to match(
             %r{
-              .*
+              #{Regexp.escape(described_class::BACKTRACE_PREFIX)}
+              .*lib/foo\.rb\:10:in
+            }x
+          )
+        end
+      end
+
+      context 'when custom backtrace cleaner is set and is proc' do
+        before do
+          described_class.level = :custom
+          described_class.backtrace_cleaner = lambda { |trace|
+            trace.reject { |line| line =~ /gems|controllers/ }
+          }
+
+          User.create!
+        end
+
+        it 'only displays lines matching custom cleaner' do
+          expect(log).to match(
+            %r{
               #{Regexp.escape(described_class::BACKTRACE_PREFIX)}
               .*lib/foo\.rb\:10:in
             }x


### PR DESCRIPTION
# Context

The existing filtering modes are not very convenient if you want to debug third-party gems behaviour. Even setting the number of lines to 10 all you get is active support and this gem traces:

```
 /bundle/gems/active_record_query_trace-1.6.2/lib/active_record_query_trace.rb:95:in `fully_formatted_trace'
      /bundle/gems/active_record_query_trace-1.6.2/lib/active_record_query_trace.rb:56:in `sql'
      /bundle/gems/activesupport-5.2.3/lib/active_support/subscriber.rb:101:in `finish'
      /bundle/gems/activesupport-5.2.3/lib/active_support/log_subscriber.rb:84:in `finish'
      /bundle/gems/activesupport-5.2.3/lib/active_support/notifications/fanout.rb:104:in `finish'
      /bundle/gems/activesupport-5.2.3/lib/active_support/notifications/fanout.rb:48:in `block in finish'
      /bundle/gems/activesupport-5.2.3/lib/active_support/notifications/fanout.rb:48:in `each'
      /bundle/gems/activesupport-5.2.3/lib/active_support/notifications/fanout.rb:48:in `finish'
      /bundle/gems/activesupport-5.2.3/lib/active_support/notifications/instrumenter.rb:44:in `finish_with_state'
      /bundle/gems/activesupport-5.2.3/lib/active_support/notifications/instrumenter.rb:29:in `instrument'
```

In this situation, configuring a custom filter seems to be a good option.

# What's inside

- [x] Added `ActiveRecordQueryTrace.backtrace_silencer` accessor
- [x] Added `:custom` level to use the configure custom silencer
- [x] ⚒ (_not related to the feature but was blocking the development_) Freeze default Rails version (Rails 6 requires different sqlite3 version, and even when I set it the tests failed—I will investigate later and provide a separate PR with Rails 6 compatibility).