### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ To colorize the output:
 ```ruby
 ActiveRecordQueryTrace.colorize = false           # No colorization (default)
 ActiveRecordQueryTrace.colorize = :light_purple   # Colorize in specific color
-ActiveRecordQueryTrace.colorize = true            # Colorize in default color
 ```
 
 Valid colors are: `:black`, `:red`, `:green`, `:brown`, `:blue`, `:purple`, `:cyan`, 


### PR DESCRIPTION
true does not default to a color, update docs (or fix colorize..)

```
Could not log "sql.active_record" event. RuntimeError: ActiveRecordQueryTrace.colorize was set to an invalid color. Use one of [true, :blue, :light_red, :black, :purple, :light_green, :red, :cyan, :yellow, :green, :gray, :light_blue, :brown, :dark_gray, :light_purple, :white, :light_cyan] or a valid color code
```