### PR TITLE
Change required ruby version to 2.4 or above including ruby 3.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ inherit_mode:
 
 AllCops:
   DisplayStyleGuide: true
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
   Exclude:
     - 'gemfiles/**/*'
 
@@ -27,6 +27,10 @@ MultilineOperationIndentation:
 
 Style/Documentation:
   Enabled: false
+
+RSpec/MultipleMemoizedHelpers:
+  Enabled: true
+  Max: 7
 
 RSpec/NestedGroups:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ language: ruby
 # List of Ruby releases: https://www.ruby-lang.org/en/downloads/releases/
 # Maintenance status of each Ruby series https://www.ruby-lang.org/en/downloads/branches/
 rvm:
-  - 2.3.8
-  - 2.4.4
-  - 2.5.3
-  - 2.6.1
+  - 2.4.10
+  - 2.5.8
+  - 2.6.6
+  - 2.7.2
   - ruby-head
 # Rails versions to run tests on.
 # We will not test on Rails versions thar are no longer supported (EOL).
@@ -30,23 +30,26 @@ matrix:
   # Some Rails versions do not work with older Ruby versions.
   exclude:
     # Rails >= 6 requires Ruby version >= 2.5.0
-    - rvm: 2.3.8
+    - rvm: 2.4.10
       gemfile: Gemfile
-    - rvm: 2.3.8
+    - rvm: 2.4.10
       gemfile: gemfiles/railsmaster.gemfile
-    - rvm: 2.4.4
-      gemfile: Gemfile
-    - rvm: 2.4.4
-      gemfile: gemfiles/railsmaster.gemfile
+    # sqlite3-1.3.13/lib/sqlite3/sqlite3_native.so: undefined symbol: rb_check_safe_obj
+    - rvm: ruby-head
+      gemfile: gemfiles/rails5.gemfile
     # I was unable to get Ruby head to work with Bundler < 2, which is required by Rails ~> 4
+    - rvm: 2.7.2
+      gemfile: gemfiles/rails4.gemfile
     - rvm: ruby-head
       gemfile: gemfiles/rails4.gemfile
     # Rails 4.0.0 only works with Ruby 2.3.8
-    - rvm: 2.4.4
+    - rvm: 2.4.10
       gemfile: gemfiles/rails40.gemfile
-    - rvm: 2.5.3
+    - rvm: 2.5.8
       gemfile: gemfiles/rails40.gemfile
-    - rvm: 2.6.1
+    - rvm: 2.6.6
+      gemfile: gemfiles/rails40.gemfile
+    - rvm: 2.7.2
       gemfile: gemfiles/rails40.gemfile
     - rvm: ruby-head
       gemfile: gemfiles/rails40.gemfile

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ D, [2019-03-03T19:50:41.062492 #25560] DEBUG -- : Query Trace:
 ```
 
 ## Requirements
-- Ruby >= 2.3;
+- Ruby >= 2.4;
 - Rails 4.2, 5.2, or 6.
 
 ## Usage

--- a/active_record_query_trace.gemspec
+++ b/active_record_query_trace.gemspec
@@ -14,10 +14,10 @@ Gem::Specification.new do |s|
   s.homepage      = 'https://github.com/brunofacca/active-record-query-trace'
   s.files         = Dir['lib/**/*']
   s.license       = 'MIT'
-  s.required_ruby_version = '~> 2.3'
+  s.required_ruby_version = '>= 2.4', '< 4.0'
   s.add_development_dependency 'activerecord', '>= 4.0.0'
-  s.add_development_dependency 'pry', '>= 0.12.2'
-  s.add_development_dependency 'pry-byebug', '>= 3.7.0'
+  s.add_development_dependency 'pry', '~> 0.13.0'
+  s.add_development_dependency 'pry-byebug', '~> 3.9.0'
   s.add_development_dependency 'rspec', '>= 3.8.0'
   s.add_development_dependency 'rubocop', '>= 0.65.0'
   s.add_development_dependency 'rubocop-rspec', '>= 1.32.0'

--- a/lib/active_record_query_trace.rb
+++ b/lib/active_record_query_trace.rb
@@ -76,7 +76,6 @@ module ActiveRecordQueryTrace
       payload[:cached] || payload[:name] == 'CACHE'
     end
 
-    # rubocop:disable Metrics/CyclomaticComplexity
     # TODO: refactor and remove rubocop:disable comments.
     def display_backtrace?(payload)
       ActiveRecordQueryTrace.enabled \
@@ -86,7 +85,6 @@ module ActiveRecordQueryTrace
         && !(ActiveRecordQueryTrace.suppress_logging_of_db_reads && db_read_query?(payload)) \
         && display_backtrace_for_query_type?(payload)
     end
-    # rubocop:enable Metrics/CyclomaticComplexity
 
     def display_backtrace_for_query_type?(payload)
       case ActiveRecordQueryTrace.query_type


### PR DESCRIPTION
This PR should change required ruby version to 2.4 or above including ruby 3.0.