### PR TITLE
Readme update for `lines = 0` for `level = :full`

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ ActiveRecordQueryTrace.ignore_cached_queries = true # Default is false.
 
 #### Limit the number of lines in the backtrace
 If you are working with a large app, you may wish to limit the number of lines 
-displayed for each query.
+displayed for each query.  If you set `level` to `:full`, you might want to set
+`lines` to `0` so you can see the entire trace.
 
 ```ruby
 ActiveRecordQueryTrace.lines = 10 # Default is 5. Setting to 0 includes entire trace.


### PR DESCRIPTION
When I was setting `level = :full`, I was very confused why the stacktrace wasn't including what I wanted.  It took me a while to find the right config option (longer than I'd like to admit, hehe).  Adding this extra sentence might help other users if they are searching the readme for `:full`.


For reference, here is the config I use in my project (disabled by default.  enable to get short `:app` logs, enable + uncomment to get `:full` logs w/ entire stacktrace):

```
# config/initializers/active_record_query_trace.rb

# Display a backtrace for each query in Rails' development console and log.
if Rails.env.development?
  ActiveRecordQueryTrace.enabled = false

  # by default, the backtrace will only include 5 lines of application code
  # uncomment the following code to get the entire backtrace including gems
  # ActiveRecordQueryTrace.level = :full
  # ActiveRecordQueryTrace.lines = 0
end
```