### PR TITLE
Add :rails_backtrace_cleaner level option

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,11 @@
+## 1.8.2 (2023-07-27)
+
+* Fix Rubocop offenses.
+
+* Remove older Ruby and Rails versions from the CI and add newer versions.
+
+* Update dependencies.
+
 ## 1.8.1 (2023-07-23)
 
 * Fix collisions with other gems in `Rails.backtrace_cleaner`

--- a/README.md
+++ b/README.md
@@ -48,13 +48,14 @@ There are three levels of debug.
 
 - `:app` - includes only application trace lines (files in the `Rails.root` directory);
 - `:rails` - includes all trace lines except the ones from the application (all files except those in `Rails.root`).
+- `:rails_backtrace_cleaner` - use a dup of the backtrace cleaner configured in `Rails.backtrace_cleaner`.
 - `:full` - full backtrace (includes all files), useful for debugging gems.
 
 ```ruby
 ActiveRecordQueryTrace.level = :app # default
 ```
 
-If you need more control you can provide a custom bactrace cleaner using the `:custom` level. For example:
+If you need more control you can provide a custom backtrace cleaner using the `:custom` level. For example:
 
 ```ruby
 ActiveRecordQueryTrace.level = :custom

--- a/lib/active_record_query_trace.rb
+++ b/lib/active_record_query_trace.rb
@@ -53,6 +53,10 @@ module ActiveRecordQueryTrace
     # The following code creates a brand new BacktraceCleaner just for the use of this Gem
     # avoiding the dealing with Rails.backtrace_cleaner
     def setup_backtrace_cleaner
+      if ActiveRecordQueryTrace.level == :rails_backtrace_cleaner
+        cleaner = Rails.backtrace_cleaner.dup
+        return
+      end
       cleaner = Rails::BacktraceCleaner.new
       remove_filters_and_silencers cleaner
       cleaner.instance_variable_set :@root, Rails.root.to_s if cleaner.instance_variable_get(:@root) == '/'

--- a/lib/active_record_query_trace/version.rb
+++ b/lib/active_record_query_trace/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveRecordQueryTrace
-  VERSION = '1.8.1'
+  VERSION = '1.8.2'
 end


### PR DESCRIPTION
This option will share the backtrace cleaner that is used to remove lines from exception backtraces, configured in applications as `Rails.backtrace_cleaner`.