### PR TITLE
cleanup: RuboCop: configure plugins as plugins

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,10 +1,10 @@
 inherit_from: .rubocop_todo.yml
 
 require:
+  - rubocop-rspec
+plugins:
   - rubocop-performance
   - rubocop-rails
-  - rubocop-rspec
-
 
 inherit_mode:
   merge:
@@ -15,7 +15,7 @@ AllCops:
   TargetRubyVersion: 2.7
   NewCops: enable
   Exclude:
-    - 'gemfiles/**/*'
+    - 'gemfiles/*'
 
 Layout/EmptyLineAfterGuardClause:
   Enabled: false


### PR DESCRIPTION
This avoids a deprecation warning being emitted on start.